### PR TITLE
Add avatar & portrait timestamp

### DIFF
--- a/src/character.php
+++ b/src/character.php
@@ -12,8 +12,10 @@ class Character
     public $world;
     public $title;
     public $avatar;
+    public $avatarTimestamp;
     public $avatarHash;
     public $portrait;
+    public $portraitTimestamp;
     public $bio;
     public $race;
     public $clan;

--- a/src/parse.php
+++ b/src/parse.php
@@ -20,6 +20,7 @@ trait Parse
             $character->title = $nameMatches['title'];
             $character->world = $nameMatches['world'];
             $character->avatar = $nameMatches['avatar'];
+            $character->avatarTimestamp = $nameMatches['avatarTimestamp'];
         }
 
         unset($nameHtml);
@@ -57,6 +58,7 @@ trait Parse
                     $character->$key = $value;
                 }
             }
+            $character->portraitTimestamp = $profileMatches["portraitTimestamp"];
         }
 
         unset($profileHtml);


### PR DESCRIPTION
Some avatar/portrait are not fully synchronized, so we need url with timestamp to view the real image.

For exemple : 
http://img2.finalfantasyxiv.com/f/60d4c256f603cd9aa38729ed8c86de89_d7a9d5f85a29d6278ec1c7adc2c8d242fc0_96x96.jpg
and 
http://img2.finalfantasyxiv.com/f/60d4c256f603cd9aa38729ed8c86de89_d7a9d5f85a29d6278ec1c7adc2c8d242fc0_96x96.jpg?1434390930